### PR TITLE
Feat update quiz by ID

### DIFF
--- a/QuizAppApi/QuizAppApi/Repositories/QuizRepository.cs
+++ b/QuizAppApi/QuizAppApi/Repositories/QuizRepository.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using QuizAppApi.Data;
 using QuizAppApi.Interfaces;
 using QuizAppApi.Models;
+using System.Reflection.Metadata.Ecma335;
 
 namespace QuizAppApi.Repositories
 {
@@ -23,11 +24,19 @@ namespace QuizAppApi.Repositories
 
         public Quiz? UpdateQuiz(int id, Quiz quiz)
         {
-            if(Save())
+            var oldQuiz = GetQuizById(id);
+            if (oldQuiz is null)
             {
-                return GetQuizById(id);
+                return null;
             }
-            return null;
+
+            oldQuiz.Questions.Clear();
+            _context.Entry(oldQuiz).State = EntityState.Detached;
+
+            _context.Quizzes.Update(quiz);
+        
+            _context.SaveChanges();
+            return GetQuizById(id);
         }
 
         public IEnumerable<Quiz> GetQuizzes()

--- a/QuizAppApi/QuizAppApi/Services/QuizService.cs
+++ b/QuizAppApi/QuizAppApi/Services/QuizService.cs
@@ -44,9 +44,9 @@ namespace QuizAppApi.Services
                 return new QuizManipulationResponseDTO { Status = "failed" };
             }
 
-            int createdQuizId = addedQuiz.Id;
+            int generatedQuizId = addedQuiz.Id;
 
-            return new QuizManipulationResponseDTO { Status = "success", Id = createdQuizId };
+            return new QuizManipulationResponseDTO { Status = "success", Id = generatedQuizId };
         }
 
         public QuizManipulationResponseDTO UpdateQuiz(int id, QuizManipulationRequestDTO updateRequest)


### PR DESCRIPTION
Changed the quiz service to the way we talked, but encountered issues in repo. If I were to just `_context.Quizzes.Update(quiz);` everything would be fine except the questions data (edited or not) would get appended instead of overwritten. 

Also needed to remove tracking on an oldQuiz object before starting tracking of a new quiz, because there cannot be two tracked objects with identical IDs.
